### PR TITLE
feat: add network method to get user bridge transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@maticnetwork/lxlyjs",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maticnetwork/lxlyjs",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Javascript developer library for interacting with Polygon LxLy Bridge",
   "main": "dist/lxly.node.js",
   "types": "dist/ts/index.d.ts",

--- a/src/lxly/bridge_util.ts
+++ b/src/lxly/bridge_util.ts
@@ -66,7 +66,7 @@ export class BridgeUtil {
         return Promise.resolve(result);
     }
 
-    private getBridgeLogData_(transactionHash: string, networkId: number, bridgeIndex = 0) {
+    private getBridgeLogData_(transactionHash: string, networkId: number, bridgeIndex: number = 0) {
         const client = this.client_.providers[networkId].provider;
         return client.getTransactionReceipt(transactionHash)
             .then(receipt => {
@@ -91,7 +91,7 @@ export class BridgeUtil {
         });
     }
 
-    getBridgeLogData(transactionHash: string, networkId: number, bridgeIndex = 0) {
+    getBridgeLogData(transactionHash: string, networkId: number, bridgeIndex: number = 0) {
         return this.getBridgeLogData_(transactionHash, networkId, bridgeIndex);
     }
 
@@ -103,7 +103,7 @@ export class BridgeUtil {
         }
     }
 
-    buildPayloadForClaim(transactionHash: string, networkId: number, bridgeIndex = 0) {
+    buildPayloadForClaim(transactionHash: string, networkId: number, bridgeIndex: number = 0) {
         return this.getBridgeLogData_(transactionHash, networkId, bridgeIndex).then((data: IBridgeEventInfo) => {
             const {
                 originNetwork,

--- a/src/services/network_service.ts
+++ b/src/services/network_service.ts
@@ -11,17 +11,21 @@ export class NetworkService {
         return `${url}`;
     }
 
-    getMerkleProof(networkID: number, depositCount: number) {
+    async getMerkleProof(networkID: number, depositCount: number) {
         const url = this.createUrl(`merkle-proof?networkId=${networkID}&depositCount=${depositCount}`);
-        return this.httpRequest.get<any>(url).then(result => {
-            return result.proof;
-        });
+        const result = await this.httpRequest.get<any>(url);
+        return result.proof;
     }
 
-    getBridgeTransactionDetails(networkID: number, depositCount: number) {
+    async getBridgeTransactionDetails(networkID: number, depositCount: number) {
         const url = this.createUrl(`bridge?net_id=${networkID}&deposit_cnt=${depositCount}`);
-        return this.httpRequest.get<any>(url).then(result => {
-            return result.deposit;
-        });
+        const result = await this.httpRequest.get<any>(url);
+        return result.deposit;
+    }
+
+    async getUserBridgeTransactions(userAddress: string, pageIndex: number = 0) {
+        const url = this.createUrl(`transactions?userAddress=${userAddress}&page=${pageIndex}`);
+        const result = await this.httpRequest.get<any>(url);
+        return result.result;
     }
 }

--- a/src/utils/bridge_client.ts
+++ b/src/utils/bridge_client.ts
@@ -19,7 +19,7 @@ export class BridgeClient {
      * @returns
      * @memberof BridgeClient
      */
-    isBridgeClaimable(txHash: string, sourceNetwork: number, bridgeIndex = 0) {
+    isBridgeClaimable(txHash: string, sourceNetwork: number, bridgeIndex: number = 0) {
         return this.bridgeUtil.getBridgeLogData(
             txHash, sourceNetwork, bridgeIndex
         ).then(result => {
@@ -42,7 +42,7 @@ export class BridgeClient {
      * @returns
      * @memberof BridgeClient
      */
-    isBridged(txHash: string, sourceNetwork: number, destinationNetwork: number, bridgeIndex = 0) {
+    isBridged(txHash: string, sourceNetwork: number, destinationNetwork: number, bridgeIndex: number = 0) {
         return this.bridgeUtil.getBridgeLogData(
             txHash, sourceNetwork, bridgeIndex
         ).then(result => {


### PR DESCRIPTION
- Added new method to consume the API endpoint that returns the user's bridge transaction history
- Added missing types from the last multiple bridge commit