### PR TITLE
fix: add missing break in DAI permit switch in getTypedData_ (BB3402573)

### DIFF
--- a/src/lxly/erc20.ts
+++ b/src/lxly/erc20.ts
@@ -575,6 +575,7 @@ export class ERC20 extends Token {
                     expiry: Math.floor((Date.now() + 3600000) / 1000),
                     allowed: true,
                 };
+                break;
             case Permit.EIP_2612:
             case Permit.UNISWAP:
 


### PR DESCRIPTION
## Bug

`getTypedData_` in `src/lxly/erc20.ts` contains a `switch (permitType)` statement where the `case Permit.DAI:` block was missing a `break` statement. This caused fall-through into `case Permit.EIP_2612:`, which overwrites `typedData.types.Permit` and `typedData.message` with the EIP-2612 schema after the DAI-specific values had already been set.

## Impact

Any call path that signs a DAI permit (e.g. `bridgeAssetWithPermit` for DAI tokens) would silently use the EIP-2612 typed data schema instead of the DAI schema. The resulting signature would be invalid against DAI's on-chain `permit()` implementation, causing the transaction to revert. DAI permits have been effectively broken since this code path was introduced.

## Fix

Added a single `break;` after the closing brace of the `typedData.message` assignment in `case Permit.DAI:`, before `case Permit.EIP_2612:`. This ensures DAI permit typed data is returned as-is without overwriting.

```ts
// Before (fall-through bug)
case Permit.DAI:
    typedData.types.Permit = [ /* DAI fields */ ];
    typedData.message = { /* DAI message */ };
case Permit.EIP_2612:  // ← DAI falls through here and overwrites above

// After (fixed)
case Permit.DAI:
    typedData.types.Permit = [ /* DAI fields */ ];
    typedData.message = { /* DAI message */ };
    break;             // ← stops fall-through
case Permit.EIP_2612:
```

Fixes BB3402573.