### PR TITLE
fix: guard optional `option` in claim methods to prevent crash

### DIFF
--- a/src/lxly/erc20.ts
+++ b/src/lxly/erc20.ts
@@ -366,7 +366,7 @@ export class ERC20 extends Token {
      */
     claimCustomERC20(transactionHash: string, sourceNetworkId: number, option?: ITransactionOption) {
         return this.bridgeUtil.buildPayloadForClaim(
-            transactionHash, sourceNetworkId, option.bridgeIndex || 0
+            transactionHash, sourceNetworkId, option?.bridgeIndex ?? 0
         ).then((payload: IClaimPayload) => {
             return this.bridge.claimMessage(
                 payload.smtProof,
@@ -397,7 +397,7 @@ export class ERC20 extends Token {
      */
     claimAsset(transactionHash: string, sourceNetworkId: number, option?: ITransactionOption) {
         return this.bridgeUtil.buildPayloadForClaim(
-            transactionHash, sourceNetworkId, option.bridgeIndex || 0
+            transactionHash, sourceNetworkId, option?.bridgeIndex ?? 0
         ).then((payload: IClaimPayload) => {
             return this.bridge.claimAsset(
                 payload.smtProof,

--- a/src/lxly/vault_bridge.ts
+++ b/src/lxly/vault_bridge.ts
@@ -70,7 +70,7 @@ export class VaultBridge extends Token {
         option?: ITransactionOption
     ) {
         return this.bridgeUtil.buildPayloadForClaim(
-            transactionHash, sourceNetworkId, option.bridgeIndex || 0
+            transactionHash, sourceNetworkId, option?.bridgeIndex ?? 0
         ).then((payload: IClaimPayload) => {
             return this.method(
                 "claimAndRedeem",


### PR DESCRIPTION
## Problem

`claimAsset` and `claimCustomERC20` (`src/lxly/erc20.ts`) and `claimAndRedeem` (`src/lxly/vault_bridge.ts`) declare their third parameter as optional:

```ts
claimAsset(transactionHash: string, sourceNetworkId: number, option?: ITransactionOption)
```

...and the JSDoc marks it `[option]` (optional). But the body dereferences it directly:

```ts
return this.bridgeUtil.buildPayloadForClaim(
    transactionHash, sourceNetworkId, option.bridgeIndex || 0
)
```

Calling these methods without the third argument - which the signature and docs permit - throws:

```
TypeError: Cannot read properties of undefined (reading 'bridgeIndex')
```

These are core claim methods, so a developer following the typed/optional contract (e.g. `claimAsset(txHash, networkId)`) hits a runtime crash. In fact `examples/lxly/erc20/claim_custom_erc20.js` calls `claimCustomERC20(bridgeTransactionHash, 0)` with no `option` argument, so this crash is already reachable from a shipped example on the current code.

## Fix

Use optional chaining + nullish coalescing at the three affected sites:

```ts
option?.bridgeIndex ?? 0
```

- `src/lxly/erc20.ts:369` (`claimCustomERC20`)
- `src/lxly/erc20.ts:400` (`claimAsset`)
- `src/lxly/vault_bridge.ts:73` (`claimAndRedeem`)

Behavior is identical when an `option` object is provided (`bridgeIndex` falls back to `0` when absent, as before). Only the omitted-`option` crash is fixed.

## Test plan

- [x] `grep` confirms no remaining unguarded `option.bridgeIndex` in `src/`.
- [x] Type-level: callers passing an option object are unaffected; callers omitting it now get the documented default `0` instead of a throw.
